### PR TITLE
[docs] Update maven plugin goal names

### DIFF
--- a/docs/client/client-overview.md
+++ b/docs/client/client-overview.md
@@ -71,8 +71,8 @@ Equivalent `pom.xml` Maven configuration
                     <execution>
                         <id>generate-graphql-client</id>
                         <goals>
-                            <goal>introspectSchema</goal>
-                            <goal>generateClient</goal>
+                            <goal>introspect-schema</goal>
+                            <goal>generate-client</goal>
                         </goals>
                         <configuration>
                             <endpoint>http://localhost:8080/graphql</endpoint>


### PR DESCRIPTION
### :pencil: Description

It appears that the suggested `graphql-kotlin-maven-plugin` goal names in the docs are incorrect

For example, when running `mvn package`, this error is returned:
```
[ERROR] Could not find goal 'introspectSchema' in plugin com.expediagroup:graphql-kotlin-maven-plugin:3.0.0 among available goals download-sdl, generate-client, generate-test-client, introspect-schema -> [Help 1]
```

This PR replaces the two incorrect (typo) goal names with the correct names.


### :link: Related Issues
